### PR TITLE
Add some optimization options to our asm

### DIFF
--- a/src/platform/systemtap.rs
+++ b/src/platform/systemtap.rs
@@ -181,7 +181,7 @@ macro_rules! sdt_asm(
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _sdt_asm(
-    ($addr:tt, options ($opt:tt), $provider:ident, $name:ident, $argstr:tt, $($arg:expr),*) => (
+    ($addr:tt, options ($($opt:ident),*), $provider:ident, $name:ident, $argstr:tt, $($arg:expr),*) => (
         asm!(concat!(r#"
 990:    nop
         .pushsection .note.stapsdt,"?","note"
@@ -208,6 +208,6 @@ _.stapsdt.base: .space 1
 "#
             ),
             $(in(reg) (($arg) as isize) ,)*
-            options($opt, readonly, nostack, preserves_flags),
+            options(readonly, nostack, preserves_flags, $($opt),*),
         )
     ));

--- a/src/platform/systemtap.rs
+++ b/src/platform/systemtap.rs
@@ -208,6 +208,6 @@ _.stapsdt.base: .space 1
 "#
             ),
             $(in(reg) (($arg) as isize) ,)*
-            options($opt, nomem, nostack, preserves_flags),
+            options($opt, readonly, nostack, preserves_flags),
         )
     ));

--- a/src/platform/systemtap.rs
+++ b/src/platform/systemtap.rs
@@ -181,7 +181,7 @@ macro_rules! sdt_asm(
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _sdt_asm(
-    ($addr:tt, options $opt:tt, $provider:ident, $name:ident, $argstr:tt, $($arg:expr),*) => (
+    ($addr:tt, options ($opt:tt), $provider:ident, $name:ident, $argstr:tt, $($arg:expr),*) => (
         asm!(concat!(r#"
 990:    nop
         .pushsection .note.stapsdt,"?","note"
@@ -208,6 +208,6 @@ _.stapsdt.base: .space 1
 "#
             ),
             $(in(reg) (($arg) as isize) ,)*
-            options $opt,
+            options($opt, nomem, nostack, preserves_flags),
         )
     ));


### PR DESCRIPTION
Since we don't actually emit code to speak of, we can let rustc/LLVM
know that we don't clobber anything, letting them avoid
saving/restoring registers or other state around the probe.

We can't mark the probe as `pure`, even though our _code_ is `pure`,
since that would enable LLVM to delete it entirely (since we have no
outputs).