### PR TITLE
Split `probe!` and `probe_lazy!` for arg eval

### DIFF
--- a/examples/semaphore.rs
+++ b/examples/semaphore.rs
@@ -1,10 +1,10 @@
-use probe::probe;
+use probe::probe_lazy;
 
 fn main() {
     let mut iter = 0;
     loop {
         iter += 1;
-        probe!(foo, iter, {
+        probe_lazy!(foo, iter, {
             // This delay is an exaggeration of the overhead of a probe argument, but it's only
             // incurred while something is attached to the probe, thanks to the semaphore.
             std::thread::sleep(std::time::Duration::from_secs(1));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,29 +94,58 @@ mod platform;
 /// * `name`     - An identifier for this specific probe.
 ///
 /// * `arg`...   - Optional data to provide with the probe. Any expression which
-///   can be cast `as isize` is allowed as an argument. The arguments might not
-///   be evaluated at all when a debugger is not attached to the probe,
-///   depending on the platform implementation, so don't rely on side effects.
+///   can be cast `as isize` is allowed as an argument. The arguments are always
+///   evaluated, even on platforms that have a no-op implementation of probes.
 ///
 /// # Example
 ///
 /// ```
-/// use probe::probe;
-/// fn main() {
-///     probe!(foo, main);
+/// # use probe::probe;
+/// // Probes are unit-typed expressions.
+/// let () = probe!(foo, main);
 ///
-///     let x = 42;
-///     probe!(foo, show_x, x);
+/// let x = 42;
+/// probe!(foo, show_x, x);
 ///
-///     let y = Some(x);
-///     probe!(foo, show_y, match y {
-///         Some(n) => n,
-///         None    => -1
-///     });
-/// }
+/// let y = Some(x);
+/// probe!(foo, show_y, match y {
+///     Some(n) => n,
+///     None    => -1
+/// });
+///
+/// let mut z = 0;
+/// probe!(foo, inc_z, { z += 1; z });
+/// assert_eq!(z, 1, "arguments are always evaluated");
 /// ```
 #[macro_export]
 macro_rules! probe(
     ($provider:ident, $name:ident $(, $arg:expr)* $(,)?)
     => ($crate::platform_probe!($provider, $name, $($arg,)*));
+);
+
+/// Define a static probe point with lazy argument evaluation.
+///
+/// This annotates a code location with a name and arguments, and compiles
+/// in metadata to let debugging tools locate it. This works the same way as
+/// [`probe!`] except that arguments are only evaluated when a debugger or
+/// tracing tool is attached to the probe. However, if a platform implementation
+/// can't determine that, it might always evaluate arguments.
+///
+/// Returns `true` if the probe is executed (and its arguments evaluated).
+///
+/// # Example
+///
+/// ```
+/// # use probe::probe_lazy;
+/// let enabled = probe_lazy!(foo, main);
+/// assert!(!enabled, "lazy probes only return true when they're active");
+///
+/// let mut z = 0;
+/// probe_lazy!(foo, inc_z, { z += 1; z });
+/// assert_eq!(z, 0, "arguments are not evaluated by default");
+/// ```
+#[macro_export]
+macro_rules! probe_lazy(
+    ($provider:ident, $name:ident $(, $arg:expr)* $(,)?)
+    => ($crate::platform_probe_lazy!($provider, $name, $($arg,)*));
 );

--- a/src/platform/default.rs
+++ b/src/platform/default.rs
@@ -2,9 +2,19 @@
 #[macro_export]
 macro_rules! platform_probe(
     ($provider:ident, $name:ident, $($arg:expr,)*) => ({
+        // Non-lazy probes always evaluate the arguments.
+        let _ = ($($arg,)*);
+    })
+);
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! platform_probe_lazy(
+    ($provider:ident, $name:ident, $($arg:expr,)*) => ({
         // Expand the arguments so they don't cause unused warnings.
         if false {
             let _ = ($($arg,)*);
         }
+        false
     })
 );

--- a/src/platform/systemtap.rs
+++ b/src/platform/systemtap.rs
@@ -2,7 +2,7 @@
 //!
 //! This is a mechanism for developers to provide static annotations for
 //! meaningful points in code, with arguments that indicate some relevant
-//! state.  Such locations may be probed by SystemTap `process.mark("name")`,
+//! state. Such locations may be probed by SystemTap `process.mark("name")`,
 //! and GDB can also locate them with `info probes` and `break -probe name`.
 //!
 //! The impact on code generation is designed to be minimal: just a single
@@ -24,7 +24,7 @@
 // register size, whereas SystemTap's long is i64 no matter the architecture.
 // However, if we could figure out types here, they could be annotated more
 // specifically, for example an argstr of "4@$0 -2@$1" indicates u32 and i16
-// respectively.  Any pointer would be fine too, like *c_char, simply 4@ or 8@
+// respectively. Any pointer would be fine too, like *c_char, simply 4@ or 8@
 // for target_word_size.
 //
 // The macros in sdt.h don't know types either, so they split each argument
@@ -39,7 +39,7 @@
 // where _SDT_ARGSIGNED is a macro using gcc builtins, so it's still resolved a
 // compile time, and %n makes it a raw literal rather than an asm number.
 //
-// This might be a possible direction for Rust SDT to follow.  For LLVM
+// This might be a possible direction for Rust SDT to follow. For LLVM
 // InlineAsm, the string would look like "${0:n}@$1", but we need the size/sign
 // for that first input, and that must be a numeric constant no matter what
 // optimization level we're at. With Rust RFC 2850 `asm!`, it might be possible
@@ -47,63 +47,68 @@
 // things like `mem::size_of::<T>()` is still hard when we don't know `T`.
 //
 // FIXME semaphores - SDT can define a short* that debuggers will increment when
-// they attach, and decrement on detach.  Thus a probe_enabled!(provider,name)
-// could return if that value != 0, to be used similarly to log_enabled!().  We
-// could even be clever and skip argument evaluation altogether, the same way
-// that log!() checks log_enabled!() first.
+// they attach, and decrement on detach. Thus a `probe_enabled!(provider,name)`
+// could return if that value != 0, to be used similarly to log_enabled!(). It
+// is difficult with mangling and macro hygene to connect two `probe!` and
+// `probe_enabled!` calls to the same symbol, unless we forced `#[no_mangle]`.
+// For now, we only use semaphores in `probe_lazy!` to skip argument evaluation
+// when there's nobody attached to see the probe.
 //
 
-#[cfg(target_pointer_width = "32")]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! platform_probe(
-    ($provider:ident, $name:ident,)
-    => ($crate::sdt_asm!(4, $provider, $name,));
-
-    ($provider:ident, $name:ident, $arg1:expr, $($arg:expr,)*)
-    => ($crate::sdt_asm!(4, $provider, $name,
-            "-4@{}", $arg1, $(" -4@{}", $arg,)*));
+    ($provider:ident, $name:ident, $($arg:expr,)*) => ({
+        $crate::sdt!([sym 0], $provider, $name, $($arg,)*);
+    })
 );
 
-#[cfg(target_pointer_width = "64")]
 #[doc(hidden)]
 #[macro_export]
-macro_rules! platform_probe(
-    ($provider:ident, $name:ident,)
-    => ($crate::sdt_asm!(8, $provider, $name,));
-
-    ($provider:ident, $name:ident, $arg1:expr, $($arg:expr,)*)
-    => ($crate::sdt_asm!(8, $provider, $name,
-            "-8@{}", $arg1, $(" -8@{}", $arg,)*));
+macro_rules! platform_probe_lazy(
+    ($provider:ident, $name:ident, $($arg:expr,)*) => ({
+        static mut SEMAPHORE: u16 = 0;
+        let enabled = unsafe { ::core::ptr::read_volatile(&SEMAPHORE) } != 0;
+        if enabled {
+            $crate::sdt!([sym "{}" SEMAPHORE], $provider, $name, $($arg,)*);
+        }
+        enabled
+    })
 );
-
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-#[doc(hidden)]
-#[macro_export]
-macro_rules! sdt_asm(
-    ($size:literal, $provider:ident, $name:ident, $($argstr:literal, $arg:expr,)*)
-    => (unsafe {
-        $crate::_sdt_asm!($size, options(att_syntax), $provider, $name, $($argstr, $arg,)*);
-    }));
-
-#[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
-#[doc(hidden)]
-#[macro_export]
-macro_rules! sdt_asm(
-    ($size:literal, $provider:ident, $name:ident, $($argstr:literal, $arg:expr,)*)
-    => (unsafe {
-        $crate::_sdt_asm!($size, options(), $provider, $name, $($argstr, $arg,)*);
-    }));
 
 // Since we can't #include <sys/sdt.h>, we have to reinvent it...
 // but once you take out the C/C++ type handling, there's not a lot to it.
 #[doc(hidden)]
 #[macro_export]
-macro_rules! _sdt_asm(
-    ($size:literal, options ($($opt:ident),*), $provider:ident, $name:ident, $($argstr:literal, $arg:expr,)*) => (
-        static mut SEMAPHORE: u16 = 0;
-        if ::core::ptr::read_volatile(&SEMAPHORE) != 0 {
-            ::core::arch::asm!(concat!(r#"
+macro_rules! sdt(
+    ([sym $symstr:literal $($sym:ident)?],
+        $provider:ident, $name:ident, $($arg:expr,)*
+    ) => (
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        $crate::sdt!([sym $symstr $($sym)?, opt att_syntax],
+            $provider, $name, $($arg,)*);
+
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+        $crate::sdt!([sym $symstr $($sym)?, opt],
+            $provider, $name, $($arg,)*);
+    );
+
+    ([sym $symstr:literal $($sym:ident)?, opt $($opt:ident)?],
+        $provider:ident, $name:ident, $($arg1:expr, $($arg:expr,)*)?
+    ) => (
+        #[cfg(target_pointer_width = "32")]
+        $crate::sdt!([sym $symstr $($sym)?, opt $($opt)?, size 4],
+            $provider, $name, $("-4@{}", $arg1, $(" -4@{}", $arg,)*)?);
+
+        #[cfg(target_pointer_width = "64")]
+        $crate::sdt!([sym $symstr $($sym)?, opt $($opt)?, size 8],
+            $provider, $name, $("-8@{}", $arg1, $(" -8@{}", $arg,)*)?);
+    );
+
+    ([sym $symstr:literal $($sym:ident)?, opt $($opt:ident)?, size $size:literal],
+        $provider:ident, $name:ident, $($argstr:literal, $arg:expr,)*
+    ) => (unsafe {
+        ::core::arch::asm!(concat!(r#"
 990:    nop
         .pushsection .note.stapsdt,"?","note"
         .balign 4
@@ -112,7 +117,7 @@ macro_rules! _sdt_asm(
 992:    .balign 4
 993:    ."#, $size, r#"byte 990b
         ."#, $size, r#"byte _.stapsdt.base
-        ."#, $size, r#"byte {}
+        ."#, $size, r#"byte "#, $symstr, r#"
         .asciz ""#, stringify!($provider), r#""
         .asciz ""#, stringify!($name), r#""
         .asciz ""#, $($argstr,)* r#""
@@ -126,9 +131,9 @@ _.stapsdt.base: .space 1
         .size _.stapsdt.base, 1
         .popsection
 .endif"#),
-                sym SEMAPHORE,
-                $(in(reg) (($arg) as isize) ,)*
-                options(readonly, nostack, preserves_flags, $($opt),*),
-            );
-        }
-    ));
+            $(sym $sym,)?
+            $(in(reg) ($arg) as isize,)*
+            options(readonly, nostack, preserves_flags $(, $opt)?),
+        )
+    });
+);

--- a/tests/readelf.rs
+++ b/tests/readelf.rs
@@ -1,3 +1,5 @@
+#![cfg(any(target_os = "linux", target_os = "android"))]
+
 use probe::probe;
 use std::env;
 use std::process::Command;


### PR DESCRIPTION
We now evaluate `probe!` arguments unconditionally, while `probe_lazy!`
avoids that when there's no observer. For SystemTap SDT, that means only
the latter defines and uses a semaphore.

Closes #19.