### PR TITLE
fix: Keep semaphores in `.probes` section

### DIFF
--- a/src/platform/systemtap.rs
+++ b/src/platform/systemtap.rs
@@ -67,6 +67,7 @@ macro_rules! platform_probe(
 #[macro_export]
 macro_rules! platform_probe_lazy(
     ($provider:ident, $name:ident, $($arg:expr,)*) => ({
+        #[link_section = ".probes"]
         static mut SEMAPHORE: u16 = 0;
         let enabled = unsafe { ::core::ptr::read_volatile(&SEMAPHORE) } != 0;
         if enabled {


### PR DESCRIPTION
See #22 for more details on the problem tackled by this PR.