### PR TITLE
Ensure the .stapsdt.base section is not removed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      # Test with image's stable Rust first
+      - run: cargo build --verbose
+      - run: cargo test --verbose
+      # Test with our MSRV
       - uses: dtolnay/rust-toolchain@1.66.0
       - run: cargo build --verbose
       - run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "probe"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Josh Stone <cuviper@gmail.com>"]
 description = "Static instrumentation probes"
 documentation = "https://docs.rs/probe/"

--- a/src/platform/systemtap.rs
+++ b/src/platform/systemtap.rs
@@ -125,7 +125,7 @@ macro_rules! sdt(
 994:    .balign 4
         .popsection
 .ifndef _.stapsdt.base
-        .pushsection .stapsdt.base,"aG","progbits",.stapsdt.base,comdat
+        .pushsection .stapsdt.base,"aGR","progbits",.stapsdt.base,comdat
         .weak _.stapsdt.base
         .hidden _.stapsdt.base
 _.stapsdt.base: .space 1

--- a/tests/readelf.rs
+++ b/tests/readelf.rs
@@ -32,3 +32,23 @@ fn check_notes() {
         .count();
     assert_eq!(count, 2);
 }
+
+#[test]
+fn check_base() {
+    // No need to create further probes. The ones introduced by check_notes are
+    // enough.
+    // Make sure readelf can find ".stapsdt.base" ELF section in the executable
+    let test_exe = env::current_exe().unwrap();
+    let output = Command::new("readelf")
+        .arg("-S")
+        .arg(&test_exe)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let count = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|line| line.contains("stapsdt.base"))
+        .count();
+    assert_eq!(count, 1);
+}


### PR DESCRIPTION
With --gc-sections option the section .stapsdt.base gets removed by multiple linker.
The behavior has been observed with gold, lld and mold whereas bfd seems to be the only one that preserves the section (at least on x86_64-unknown-linux-gnu target).
Since Rust >=1.90, lld has become the default linker making the issue even more acute.
The small series adds the `SHF_GNU_RETAIN` flag to the section preventing the linker from GC'ing `.stapsdt.base`.